### PR TITLE
fix: Use platform.system() for cross-platform OS detection

### DIFF
--- a/pegasus/prompts/system.py
+++ b/pegasus/prompts/system.py
@@ -3,6 +3,7 @@ import jinja2
 from pegasus.config.config import Config
 import json
 import os, sys
+import platform
 from datetime import datetime
 from pegasus.tools.base import Tool
 
@@ -51,7 +52,8 @@ def _get_environment_section(config: Config) -> str:
     template = template_env.get_template("environment.j2")
     cwd = config.cwd.as_posix()
     shell_info = _get_shell_info()
-    return template.render({"now": datetime.now(), "os_info": os.uname().sysname, "cwd": cwd, "shell_info": shell_info})
+    os_info = platform.system()
+    return template.render({"now": datetime.now(), "os_info": os_info, "cwd": cwd, "shell_info": shell_info})
 
 def _get_security_guidelines_section(config: Config) -> str:
     """


### PR DESCRIPTION
## Problem
`pegasus-cli` fails on Windows with `AttributeError: module 'os' has no attribute 'uname'`. The agent startup code uses `os.uname().sysname`, which is only available on Unix-like systems (Linux, macOS).

## Solution
Replace `os.uname().sysname` with `platform.system()`, which is available and works identically on Windows, macOS, and Linux.

## Changes
- Add `import platform` to `pegasus/prompts/system.py`
- Replace `os.uname().sysname` with `platform.system()` in `_get_environment_section()`

This is a minimal, cross-platform fix that allows the agent to start on all major operating systems.