### PR TITLE
fix: Use platform.system() for cross-platform OS detection

### DIFF
--- a/pegasus/prompts/system.py
+++ b/pegasus/prompts/system.py
@@ -3,6 +3,7 @@ import jinja2
 from pegasus.config.config import Config
 import json
 import os, sys
+import platform
 from datetime import datetime
 from pegasus.tools.base import Tool
 
@@ -51,7 +52,8 @@ def _get_environment_section(config: Config) -> str:
     template = template_env.get_template("environment.j2")
     cwd = config.cwd.as_posix()
     shell_info = _get_shell_info()
-    return template.render({"now": datetime.now(), "os_info": os.uname().sysname, "cwd": cwd, "shell_info": shell_info})
+    os_info = platform.system()
+    return template.render({"now": datetime.now(), "os_info": os_info, "cwd": cwd, "shell_info": shell_info})
 
 def _get_security_guidelines_section(config: Config) -> str:
     """


### PR DESCRIPTION
**## Summary**

This pull request fixes a Windows compatibility issue caused by the use of the Unix-specific `os.uname()` function.

**## Problem**

When running Pegasus on Windows, the application raised the following error:

AttributeError: module 'os' has no attribute 'uname'

This occurred because `os.uname()` is only available on Unix-like operating systems such as Linux and macOS.

**## Solution**

Replaced `os.uname().sysname` with `platform.system()` and added the required `platform` import.

`platform.system()` provides equivalent operating system information while supporting Windows, Linux and macOS.

**## Testing**

Tested by launching Pegasus on Windows. The previous `AttributeError` no longer occurs and the application proceeds past this point.